### PR TITLE
resolve #4401 updating spanish.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/spanish.xml
+++ b/PowerEditor/installer/nativeLang/spanish.xml
@@ -402,7 +402,7 @@ The comments are here for explanation, it's not necessary to translate them.
 				<Item id="1661" name="Seguir archivo actual"/>
 				<Item id="1641" name="Buscar solo en el archivo actual"/>
 				<Item id="1686" name="Transparencia"/>
-				<Item id="1703" name="&amp;. se ajusta a línea nueva"/>
+				<Item id="1703" name="&amp;. para nueva línea"/>
 				<Item id="1721" name="▲"/>
 				<Item id="1723" name="▼ Siguiente"/>
 				<Item id="1725" name="Copiar el texto marcado"/>


### PR DESCRIPTION
Resolves issue #4401 "Spanish translation: Search dialog items do not fit (translated texts too long)". Now the text fits the search dialog

Before:
<Item id="1703" name="&amp;. se ajusta a línea nueva"/>

Now:
<Item id="1703" name="&amp;. para nueva línea"/>